### PR TITLE
Fix warnings from clang and gcc:

### DIFF
--- a/basic.c
+++ b/basic.c
@@ -1,25 +1,26 @@
 #include <stdio.h>
 #include "basic.h"
 
-PRINTS_() { puts((char*)*sp++); STEP; }
+int PRINTS_() { puts((char*)*sp++); STEP; }
 
-kwdhook_(char *msg) {
+int kwdhook_(char *msg) {
 	if (!strcmp(msg,"PRINTS"))
 		expr(), emit(PRINTS_);
 	else	return 0;
 	return 1;
 }
 
-main(int argc, char **argv) {
+int main(int argc, char **argv) {
 	FILE *sf=stdin;
 	initbasic(0);
 	kwdhook=kwdhook_;
-	if (argv[1])
-		if (sf=fopen(argv[1],"r"))
+	if (argv[1]) {
+		if ((sf=fopen(argv[1],"r")) != NULL)
 			compile++;
 		else {
 			printf("CANNOT OPEN: %s\n", argv[1]);
 			return 255;
 		}
+	}
 	return interp(sf);
 }


### PR DESCRIPTION
o include <stdint.h> for intptr_t
o use intptr_t for storing both pointers and ints rather than int.
o include <ctypes.h> for isspace()
o tag all implicit returns as int or void
o fix one bug where ECHO_ didn't step -- really a bug?
o tag all functions that take no args as (void).
o forward declare expr and err
o fix some printf formats / castingo
o add some explicit parens for assignment operators in if statements